### PR TITLE
Firewheel-Bugfix

### DIFF
--- a/core/src/com/projectkorra/projectkorra/firebending/combo/FireWheel.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/combo/FireWheel.java
@@ -109,7 +109,7 @@ public class FireWheel extends FireAbility implements ComboAbility {
 			return;
 		} else if (topBlock.getType() == Material.FIRE) {
 			topBlock = topBlock.getRelative(BlockFace.DOWN);
-		} else if (ElementalAbility.isPlant(topBlock)) {
+		} else if (ElementalAbility.isPlant(topBlock) && topBlock.getType() != Material.MOSS_BLOCK) {
 			topBlock.breakNaturally();
 			topBlock = topBlock.getRelative(BlockFace.DOWN);
 		} else if (ElementalAbility.isAir(topBlock.getType())) {


### PR DESCRIPTION
Firewheel no longer removes moss

## Summary
What does this PR do?
Stops Firewheel from breaking moss, checks if "plant" is moss, if the plant is moss it does not execute the ordinary plant code. https://youtu.be/F4A5daBLI6U

## Details
Anything else worth mentioning.